### PR TITLE
Remove $ symbol from CalculatorTests.kt tip_result check.

### DIFF
--- a/app/src/androidTest/java/com/example/tiptime/CalculatorTests.kt
+++ b/app/src/androidTest/java/com/example/tiptime/CalculatorTests.kt
@@ -42,7 +42,7 @@ class CalculatorTests {
         onView(withId(R.id.calculate_button))
             .perform(click())
         onView(withId(R.id.tip_result))
-            .check(matches(withText(containsString("$10.00"))))
+            .check(matches(withText(containsString("10.00"))))
 
     }
 
@@ -55,7 +55,7 @@ class CalculatorTests {
         onView(withId(R.id.calculate_button))
             .perform(click())
         onView(withId(R.id.tip_result))
-            .check(matches(withText(containsString("$9.00"))))
+            .check(matches(withText(containsString("9.00"))))
     }
 
     @Test
@@ -67,7 +67,7 @@ class CalculatorTests {
         onView(withId(R.id.calculate_button))
             .perform(click())
         onView(withId(R.id.tip_result))
-            .check(matches(withText(containsString("$8.00"))))
+            .check(matches(withText(containsString("8.00"))))
     }
 
     @Test
@@ -81,6 +81,6 @@ class CalculatorTests {
         onView(withId(R.id.calculate_button))
             .perform(click())
         onView(withId(R.id.tip_result))
-            .check(matches(withText(containsString("$7.50"))))
+            .check(matches(withText(containsString("7.50"))))
     }
 }


### PR DESCRIPTION
The $ symbol is region specific and will cause tests to fail for devices in another region.
After removing $ symbol the instrumentation tests still pass.

Resolves #390 